### PR TITLE
chore: update @lando/php to ^1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v1.12.0 (unreleased)
 
+* Updated `@lando/php` to `^1.11.0` for MySQL client auto-detection fix
 * Added PHP 8.5 support [#76](https://github.com/lando/symfony/pull/76)
 * Updated to [@lando/php@^1.10.0](https://github.com/lando/php/releases/tag/v1.10.0)
 * Fixed release workflow trigger for draft releases

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lando/memcached": "^1.4.2",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.10.0",
+        "@lando/php": "^1.11.0",
         "@lando/postgres": "^1.5.0",
         "@lando/redis": "^1.2.3",
         "lodash": "^4.17.21"
@@ -1666,9 +1666,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.10.0.tgz",
-      "integrity": "sha512-1+WO35CixeaZKaQ+NTi+Xii1xk+GYIJvbbqVI1Ba10RFMBTsUK4y99hZCKrCLW3KqPfe6f4ufAfMllALbnHHmw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.0.tgz",
+      "integrity": "sha512-E2uj58X1+Kk+XYnDhpnl04nR60/lBt/jwhmhNPryis6t9EwMDLDJ8YI8UUjVSxvUL1NbVlYp4X90Rc3EHsWv1g==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@lando/memcached": "^1.4.2",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.10.0",
+    "@lando/php": "^1.11.0",
     "@lando/postgres": "^1.5.0",
     "@lando/redis": "^1.2.3",
     "lodash": "^4.17.21"


### PR DESCRIPTION
Updates @lando/php to ^1.11.0 for MySQL client auto-detection fix in recipe-based services (lando/php#223).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only bump plus changelog update; behavior changes are confined to the upstream `@lando/php` package.
> 
> **Overview**
> Updates the dependency on `@lando/php` from `^1.10.0` to `^1.11.0`, including the corresponding `package-lock.json` resolution/integrity changes.
> 
> Adds an unreleased changelog entry calling out the bump as a fix for MySQL client auto-detection in recipe-based services.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 26215ebe9828c1ebbab0d4d7a9d737e2134b6d4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->