### PR TITLE
feat: promote npm edge tag to latest when prerelease is promoted

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,32 @@ on:
   release:
     types:
       - published
-
+      - released
 jobs:
+  # When a prerelease is promoted to a full release, update the npm latest tag
+  promote:
+    if: github.event.action == 'released'
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: Install node 20
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+      - name: Promote edge to latest
+        run: |
+          VERSION=$(echo "$TAG_NAME" | sed 's/^v//')
+          PACKAGE=$(node -p "require('./package.json').name")
+          npm dist-tag add "$PACKAGE@$VERSION" latest
+          echo "::notice title=Promoted $VERSION to latest::The latest tag now points to $VERSION (was edge-only)"
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_DEPLOY_TOKEN}}
+
   deploy:
+    if: github.event.action == 'published'
     runs-on: ${{ matrix.os }}
     env:
       TERM: xterm


### PR DESCRIPTION
## Problem

When a release is published as a prerelease, it gets tagged as `edge` on npm. Later, when the release is promoted to a full release in GitHub, the npm `latest` tag doesn't update because the workflow only triggered on `published`.

## Solution

- Added `released` to the release workflow trigger types
- New lightweight `promote` job that only runs `npm dist-tag add latest` — no install, no lint, no tests, no re-publish
- Only fires on the `released` event (when a prerelease is promoted to full release)
- Existing `deploy` job is now explicitly gated to `published` events only (no behavior change)
- Uses `TAG_NAME` env var instead of direct interpolation to prevent script injection

## Flow

1. Publish as prerelease → full pipeline runs, publishes with `edge` tag (unchanged)
2. Promote release → uncheck prerelease → `promote` job runs, points `latest` to that version (~15s)

The `dist-tag add` command is idempotent, so if both `published` and `released` fire on a fresh non-prerelease publish, the redundant promote is harmless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adjusts npm dist-tags and job triggering; low code risk, but could affect release automation if misconfigured.
> 
> **Overview**
> Updates the `release.yml` workflow to also run on GitHub `release` events of type `released`, and adds a new `promote` job that runs only for `released` actions to move npm `latest` to the promoted version via `npm dist-tag add`.
> 
> Gates the existing `deploy` job to run only on `published` actions, avoiding re-running the publish pipeline during promotions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abd81f5d444a4e4221e50b2c672787629ddbe2f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->