### PR TITLE
feat: update @lando/php to ^1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated to [@lando/php@1.12.0](https://github.com/lando/php/releases/tag/v1.12.0) for mod_headers/mod_expires and xdebug log fix
+
 ## v1.12.2 - [March 2, 2026](https://github.com/lando/symfony/releases/tag/v1.12.2)
 
 * Removed `--ansi` flag from composer tooling command to prevent escape codes in redirected output

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@lando/memcached": "^1.4.2",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.11.1",
+        "@lando/php": "^1.12.0",
         "@lando/postgres": "^1.5.0",
         "@lando/redis": "^1.2.3",
         "lodash": "^4.17.21"
@@ -1666,9 +1666,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.1.tgz",
-      "integrity": "sha512-3l6oEj6iZxL4vj59YbOinfu4ktUXYfHe7UlP1W5wePTaQH9K+RBCg8eCsPBmliQzc9ltX6JqvDYrAx2KN5K8Dw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.12.0.tgz",
+      "integrity": "sha512-yHhjdtGv0zgylfOubbWz09ufTr8yfi7so262RDJT5P03T24LfHPOBLFLTtdI8I1k0kzH9phxhQ4aZyex9TMhsg==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",
@@ -1685,7 +1685,7 @@
       }
     },
     "node_modules/@lando/php/node_modules/@lando/nginx": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "bundleDependencies": [
         "lodash"
       ],

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@lando/memcached": "^1.4.2",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.11.1",
+    "@lando/php": "^1.12.0",
     "@lando/postgres": "^1.5.0",
     "@lando/redis": "^1.2.3",
     "lodash": "^4.17.21"


### PR DESCRIPTION
## Changes

- Updated `@lando/php` to `^1.12.0`

## What's in @lando/php v1.12.0

- Enabled mod_headers and mod_expires Apache modules by default ([php#244](https://github.com/lando/php/pull/244))
- Fixed xdebug log file ownership issue when build_as_root or run_as_root creates /tmp/xdebug.log as root ([php#242](https://github.com/lando/php/pull/242))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency bump changes the underlying PHP service image/config, which can subtly affect local dev runtime behavior (e.g., Apache module defaults) even though no project code changes.
> 
> **Overview**
> Updates this plugin to use `@lando/php@^1.12.0`, with corresponding `package-lock.json` refresh.
> 
> Adds an UNRELEASED changelog entry noting the upstream changes (Apache `mod_headers`/`mod_expires` enabled by default and an xdebug log ownership fix).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7da844af5f043f74e34d8ccd8ec285b5c0d6451b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->